### PR TITLE
Add 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Running at [exun.co](https://exun.co/shorten).
 PORT=3000
 SECRET=<secret for signing cookies>
 NODE_ENV=<'development' or 'production'>
-USERNAME=<login username>
-PASSWORD=<login password>
 ```
 2. Get the Google Cloud Credentials from [Ananay](https://ananayarora.com), name the file as 'client_secret.json' and put it in the root directory of this project (in the same folder as package.json, app.js, etc.)
 3. Create a file called `.authorized` with the emails of those who are allowed to make shortlinks. Put each email in a new line.

--- a/app.js
+++ b/app.js
@@ -29,6 +29,10 @@ app.use(async (ctx, next) => {
   try {
     await next()
   } catch (err) {
+    if (err.status === 404) {
+      await ctx.render('404')
+    }
+
     ctx.status = err.status || 500
     Sentry.captureException(err)
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -79,7 +79,6 @@ router.get('*', async ctx => {
   }
   const shortlink = await Shortlink.query().findOne('slug', pathname.slice(1))
   if (!shortlink) {
-    console.log('asasdasdasd')
     await ctx.render('404')
     ctx.status = 404
     return

--- a/routes/index.js
+++ b/routes/index.js
@@ -79,7 +79,9 @@ router.get('*', async ctx => {
   }
   const shortlink = await Shortlink.query().findOne('slug', pathname.slice(1))
   if (!shortlink) {
-    ctx.throw(404)
+    console.log('asasdasdasd')
+    await ctx.render('404')
+    ctx.status = 404
     return
   }
   ctx.redirect(shortlink.target)

--- a/routes/index.js
+++ b/routes/index.js
@@ -79,8 +79,7 @@ router.get('*', async ctx => {
   }
   const shortlink = await Shortlink.query().findOne('slug', pathname.slice(1))
   if (!shortlink) {
-    await ctx.render('404')
-    ctx.status = 404
+    ctx.throw(404)
     return
   }
   ctx.redirect(shortlink.target)

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,11 +1,11 @@
 const Router = require('koa-router')
 
+const path = require("path");
+const fs = require('fs');
 const Shortlink = require('../models/Shortlink')
 const auth = require('../lib/auth')
 const normalizeUrl = require('../lib/normalizeUrl')
 const GoogleController = require("../controllers/GoogleController");
-const path = require("path");
-const fs = require('fs');
 
 const router = new Router()
 
@@ -44,14 +44,12 @@ router.get('/shorten/login', async ctx => {
 router.get('/shorten/auth', async ctx => {
   const { code } = ctx.request.query;
   const profile = await GoogleController.callbackHandlerAndGetProfile(code);
-  const profile_pic = profile.picture;
-  const name = profile.name;
-  const email = profile.email;
+  const {picture, name, email} = profile
   const data = fs.readFileSync(path.resolve(__dirname, '../.authorized'));
   if (data.includes(email)) {
     ctx.session.email = email;
     ctx.session.name = name;
-    ctx.session.profile_pic = profile_pic;
+    ctx.session.profile_pic = picture;
     ctx.redirect('/shorten');
   } else {
     ctx.redirect('/unauthorized');

--- a/routes/index.js
+++ b/routes/index.js
@@ -65,14 +65,6 @@ router.get('/unauthorized', async ctx => {
   })
 });
 
-// router.post('/shorten/login', async ctx => {
-//   const { username, password } = ctx.request.body
-//   if (username === process.env.USERNAME && password === process.env.PASSWORD) {
-//     ctx.session.username = username
-//     ctx.redirect('/shorten')
-//   } else await ctx.render('login', { error: 'Incorrect username or password' })
-// })
-
 router.get('/shorten/logout', async ctx => {
   ctx.session = null
   ctx.redirect('/shorten/login')

--- a/views/404.html
+++ b/views/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link rel="shortcut icon" href="/favicon.png" />
+    <title>Shorten | exun.co</title>
+    <link rel="stylesheet" href="/normalize.css" />
+    <link rel="stylesheet" href="/skeleton.css" />
+    <link rel="stylesheet" href="/style.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <div class="container">
+      <div class="form-container">
+        <h1>404 :/</h1>
+        <p>
+          The page you were looking for could not be found.
+        </p>
+        <p>
+          If you think this is a mistake, please
+          <a href="mailto:exun@dpsrkp.net">contact us</a>.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This is what it looks like -
![screenshot](https://user-images.githubusercontent.com/30556800/87057644-bdf85080-c224-11ea-9285-5d6ea74cff58.png)

Here's the changed route, let me know if I've done anything wrong - 
```js
/**
 * Redirect actual shortlinks.
 */
router.get('*', async ctx => {
  const { pathname } = ctx.URL
  if (pathname === '/') {
    ctx.redirect('https://exunclan.com')
    return
  }
  const shortlink = await Shortlink.query().findOne('slug', pathname.slice(1))
  if (!shortlink) {
    await ctx.render('404')
    ctx.status = 404
    return
  }
  ctx.redirect(shortlink.target)
})
```
